### PR TITLE
enhance role extraction to also provide client roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+
+*.egg-info
+
+# pycharm IDE artifacts
+.idea/


### PR DESCRIPTION
This PR fixes #19 

Client roles are now extracted from the access token and exposed to the custom `LOAD_USER_ROLES_FUNCTION`.

The proposed implementation refactors role extraction into a standalone function in the hope to make the code more readable and easier to test.

This PR also includes a `.gitignore` file with basic rules for ignoring unwanted artifacts. While not strictly related to the issue being addressed here, it seemed like a worthy addition. If you don't want it please ask for changes and I'll remove it.